### PR TITLE
Add an option for cdnjs to jQuery CDNs

### DIFF
--- a/Sources/Actions/Admin/Features.php
+++ b/Sources/Actions/Admin/Features.php
@@ -1583,6 +1583,7 @@ class Features implements ActionInterface
 				'jquery_source',
 				[
 					'cdn' => Lang::$txt['jquery_google_cdn'],
+					'cloudflare_cdn' => Lang::$txt['jquery_cloudflare_cdn'],
 					'jquery_cdn' => Lang::$txt['jquery_jquery_cdn'],
 					'microsoft_cdn' => Lang::$txt['jquery_microsoft_cdn'],
 					'local' => Lang::$txt['jquery_local'],

--- a/Sources/Theme.php
+++ b/Sources/Theme.php
@@ -2812,6 +2812,7 @@ class Theme
 		// Add the JQuery library to the list of files to load.
 		$jQueryUrls =  [
 			'cdn' => 'https://ajax.googleapis.com/ajax/libs/jquery/' . JQUERY_VERSION . '/jquery.min.js',
+			'cloudflare_cdn' => 'https://cdnjs.cloudflare.com/ajax/libs/' . JQUERY_VERSION . '/jquery.min.js',
 			'jquery_cdn' => 'https://code.jquery.com/jquery-' . JQUERY_VERSION . '.min.js',
 			'microsoft_cdn' => 'https://ajax.aspnetcdn.com/ajax/jQuery/jquery-' . JQUERY_VERSION . '.min.js',
 		];

--- a/Themes/default/languages/Help.english.php
+++ b/Themes/default/languages/Help.english.php
@@ -264,7 +264,7 @@ $helptxt['enableErrorQueryLogging'] = 'This will include the full query sent to 
 $helptxt['disallow_sendBody'] = 'This setting removes the option to receive the text of replies, posts, and personal messages in notification emails.<br><br>Often, members will reply to the notification email, which in most cases means the webmaster receives the reply.';
 $helptxt['enable_ajax_alerts'] = 'This option allows your members to receive AJAX notifications. This means that members don\'t need to refresh the page to get new notifications.<br><strong>DO NOTE:</strong> This option might cause a severe load at your server with many users online.';
 $helptxt['alerts_auto_purge'] = 'Once an alert has been read, it is rarely needed again. For performance reasons, it is a good idea to automatically delete them after a while.';
-$helptxt['jquery_source'] = 'This will determine the source used to load the jQuery Library. <em>Google CDN, jQuery CDN</em> and <em>Microsoft CDN</em> will load the jQuery library from those respective CDN networks. <em>Local</em> will only use the local source. <em>Custom</em> allows you to specify a custom URL for the library.';
+$helptxt['jquery_source'] = 'This will determine the source used to load the jQuery Library. <em>Cloudflare CDN (cdnjs), Google CDN, jQuery CDN</em> and <em>Microsoft CDN</em> will load the jQuery library from those respective CDN networks. <em>Local</em> will only use the local source. <em>Custom</em> allows you to specify a custom URL for the library.';
 $helptxt['compactTopicPagesEnable'] = 'This will just show a selection of the number of pages.<br><em>Example:</em>
 		&quot;3&quot; to display: 1 ... 4 [5] 6 ... 9 <br>
 		&quot;5&quot; to display: 1 ... 3 4 [5] 6 7 ... 9';

--- a/Themes/default/languages/ManageSettings.english.php
+++ b/Themes/default/languages/ManageSettings.english.php
@@ -76,6 +76,7 @@ $txt['jquery_source'] = 'Source for the jQuery Library';
 $txt['jquery_custom_label'] = 'Custom';
 $txt['jquery_custom'] = 'Custom URL to the jQuery Library';
 $txt['jquery_local'] = 'Local';
+$txt['jquery_cloudflare_cdn'] = 'Cloudflare CDN (cdnjs)';
 $txt['jquery_google_cdn'] = 'Google CDN';
 $txt['jquery_jquery_cdn'] = 'jQuery CDN';
 $txt['jquery_microsoft_cdn'] = 'Microsoft CDN';


### PR DESCRIPTION
#### Description
This PR adds built-in support for loading jQuery from Cloudflare's CDN (aka "cdnjs"). While it doesn't add any additional benefits, it gives us another solid option in addition to the ones provided.